### PR TITLE
Basic grammar fixes

### DIFF
--- a/src/calendar.pest
+++ b/src/calendar.pest
@@ -15,12 +15,12 @@ entry = {date ~ option* ~ description_block}
         day=@{(ASCII_NONZERO_DIGIT~ASCII_DIGIT?)|"*"}
 
     option = {"#" ~ ASCII_ALPHA+ ~ option_parameter}
-        option_parameter = _{parameter ~ ("," ~ parameter)*} // Ignore parameter block, just give an array of parameter
+        option_parameter = _{"(" ~ parameter ~ ("," ~ parameter)* ~ ")"} // Ignore parameter block, just give an array of parameter
             parameter = ${time_expression | ASCII_ALPHANUMERIC+}
                 time_expression={time_unit ~ time_type} // 1w or 23d or 3m or 5y
                     time_type= @{"d"|"w"|"m"|"y"} // day, week, month, year
                     time_unit= @{ASCII_NONZERO_DIGIT+}
 
-    description_block= _{"|" ~ description} // Ignore the separator
+    description_block= _{description} // Ignore the separator
         description = @{(!NEWLINE ~ ASCII)+}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ mod tests {
     use lazy_static::lazy_static;
     use pest_test::{PestTester, TestError};
 
+
     lazy_static! {
         static ref COLORIZE: bool = {
                     option_env!("CARGO_TERM_COLOR").unwrap_or("always") != "never"
@@ -29,30 +30,25 @@ mod tests {
         //PestTester::from_defaults(Rule::calendar, HashSet::new());
     }
 
-    #[test]
-    fn test_every_day_task() -> Result<(), TestError<Rule>> {
-        let res = (*TESTER).evaluate_strict("every_day_task");
-        if let Err(pest_test::TestError::Diff { ref diff }) = res {
+    macro_rules! pest_tests {
+        ($($name: ident), *) => {
+            $(
+                #[test]
+                fn $name() -> Result<(), TestError<Rule>> {
+                    let res = (*TESTER).evaluate_strict(stringify!($name));
+                    if let Err(pest_test::TestError::Diff {ref diff}) = res {
                         diff.print_test_result(*COLORIZE).unwrap();
                     }
-        res
+                    res
+                }
+
+            )*
+        }
     }
 
-    #[test]
-    fn event_early_notification() -> Result<(), TestError<Rule>> {
-        let res = (*TESTER).evaluate_strict("event_early_notification");
-        if let Err(pest_test::TestError::Diff { ref diff }) = res {
-                        diff.print_test_result(*COLORIZE).unwrap();
-                    }
-        res
-    }
-
-    #[test]
-    fn small_calendar() -> Result<(), TestError<Rule>> {
-        let res = (*TESTER).evaluate_strict("small_calendar");
-        if let Err(pest_test::TestError::Diff { ref diff }) = res {
-                        diff.print_test_result(*COLORIZE).unwrap();
-                    }
-        res
+    pest_tests! {
+        every_day_task,
+        event_early_notification,
+        small_calendar
     }
 }

--- a/tests/pest/event_early_notification.txt
+++ b/tests/pest/event_early_notification.txt
@@ -3,7 +3,7 @@ Event with early notification
 ========
 
 
-24-3-1 #id 23 #notifyBefore 1w | Prepare wedding
+24-3-1 #id (23) #notifyBefore (1w) Prepare wedding
 
 ========
 

--- a/tests/pest/every_day_task.txt
+++ b/tests/pest/every_day_task.txt
@@ -2,7 +2,7 @@ every_day_task
 
 =======
 
-*-*-* #priority 1| Feed dog
+*-*-* #priority (1) Feed dog
 
 =======
 

--- a/tests/pest/small_calendar.txt
+++ b/tests/pest/small_calendar.txt
@@ -2,14 +2,14 @@ Small calendar file
 
 ========
 
-*-*-* #priority 1| Feed dog
-*-*-*   #priority      1    | Prepare dinner
-*-*-* #priority 4 | Check mail
-*-*-* #REPEAT 1w | Do the laundry
+*-*-* #priority(1) Feed dog
+*-*-*   #priority      (1)     Prepare dinner
+*-*-* #priority (4)  Check mail
+*-*-* #REPEAT ( 1w )  Do the laundry
 
-*-5-2 #extend 1w | Bob's birthday
+*-5-2 #extend (  1w)  Bob's birthday
 
-24-3-1 #id 23 #notifyBefore 1w | Prepare wedding
+24-3-1 #id (23) #notifyBefore( 1w)  Prepare wedding
 
 
 ========


### PR DESCRIPTION
It's better for the grammar to enclose option arguments in parenthesis. Also | is not needed for entry description anymore.